### PR TITLE
Handle role removal correctly in IAM instance profiles.

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -210,7 +210,20 @@ func instanceProfileSetRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
 }
 
 func instanceProfileRemoveAllRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
+	removedSingleRole := ""
+	if role, ok := d.GetOk("role"); ok {
+		err := instanceProfileRemoveRole(iamconn, d.Id(), role.(string))
+		if err != nil {
+			return fmt.Errorf("Error removing role %s from IAM instance profile %s: %s", role, d.Id(), err)
+		}
+		removedSingleRole = role.(string)
+	}
+
 	for _, role := range d.Get("roles").(*schema.Set).List() {
+		if role.(string) == removedSingleRole {
+			continue
+		}
+
 		err := instanceProfileRemoveRole(iamconn, d.Id(), role.(string))
 		if err != nil {
 			return fmt.Errorf("Error removing role %s from IAM instance profile %s: %s", role, d.Id(), err)


### PR DESCRIPTION
If an aws_iam_instance_profile resource is created with `role` set (vs.
`roles`, which is deprecated) then the resulting resource is written
to the state file with only `role` populated.

An IAM instance profile cannot be deleted as long as there is a role
attached.

If an attempt is made to delete the instance profile resource without an
intervening refresh, the provider will read the (empty) `roles` property,
detach no roles, then try to delete the resource. The delete will fail.
Note that most users won't see this because apply and plan refresh first,
and the code for Get always sets `roles`.

These changes consider the value of `role` in
`instanceProfileRemoveAllRoles` before considering `roles`. If `role` is
populated, the role named therein is removed. The removed role is
tracked s.t. if it is also present in `roles` no attempt is made to
remove it twice.