### PR TITLE
Include Lambda ENI cleanup when retrying security group or subnet delete

### DIFF
--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -288,10 +288,6 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())
 
-	if err := deleteLingeringLambdaENIs(conn, "subnet-id", d.Id()); err != nil {
-		return fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
-	}
-
 	req := &ec2.DeleteSubnetInput{
 		SubnetId: aws.String(d.Id()),
 	}
@@ -302,6 +298,10 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 		Timeout:    10 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
+			if err := deleteLingeringLambdaENIs(conn, "subnet-id", d.Id()); err != nil {
+				return 42, "failure", fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
+			}
+
 			_, err := conn.DeleteSubnet(req)
 			if err != nil {
 				if apiErr, ok := err.(awserr.Error); ok {


### PR DESCRIPTION
We've seen cases where delete fails due to timeout. We assume the cause is
lingering resources in the subnet, which would have to be these ENIs.

It seems possible that a Lambda invocation at the wrong time could result in
an ENI popping up between when we search for them and when we try to delete
the subnet or security group.