### PR TITLE
Typo fix on FIFO queue name error

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -695,7 +695,7 @@ func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
 	}
 
 	if !regexp.MustCompile(`\.fifo$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("FIFO queue name should ends with \".fifo\": %v", value))
+		errors = append(errors, fmt.Errorf("FIFO queue name should end with \".fifo\": %v", value))
 	}
 
 	return


### PR DESCRIPTION
Replaced 'should ends' with 'should end'

Simple typo fix.
