### PR TITLE
Increase timeout for ECS Service wait_for_steady_state

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -1193,7 +1193,7 @@ func resourceAwsEcsWaitForServiceSteadyState(d *schema.ResourceData, meta interf
 		Pending:    []string{"false"},
 		Target:     []string{"true"},
 		Refresh:    resourceAwsEcsServiceIsSteadyStateFunc(d, meta),
-		Timeout:    10 * time.Minute,
+		Timeout:    15 * time.Minute,
 		MinTimeout: 1 * time.Second,
 	}
 


### PR DESCRIPTION
The timeout was previously set to 10m to match https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ECS.WaitUntilServicesStable.  However, it is very common for ECS services to take just over 10 minutes to get to a steady state after an update, particularly if they are attached to a load balancer - which defaults to just about 10 minutes of waiting for healthy and waiting to drain old tasks during an update.

Fixes https://github.com/pulumi/pulumi-awsx/issues/354.