### PR TITLE
Update autoscaling docs to reflect renamed property

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -369,7 +369,7 @@ The following arguments are supported:
 * `termination_policies` (Optional) A list of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default`.
 * `suspended_processes` - (Optional) A list of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`.
 Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly.
-* `tag` (Optional) Configuration block(s) containing resource tags. Conflicts with `tags`. Documented below.
+* `tag` (Optional) Configuration block(s) containing resource tags. Conflicts with `tags_collection`. Documented below.
 * `tags` (Optional) Set of maps containing resource tags. Conflicts with `tag`. Documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.


### PR DESCRIPTION
I'm not sure this is the best way to do override this doc string, but we need to make this match the `tags_collection` name that we use in `pulumi-aws` (https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go#L632)