### PR TITLE
Add back in removeAddons to eks/cluster.go. 

### DIFF
--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -380,6 +380,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("waiting for EKS Cluster (%s) create: %s", d.Id(), err)
 	}
 
+	if err = removeAddons(d, conn); err != nil {
+		return err
+	}
+
 	return resourceClusterRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Changes proposed in this pull request:

* removeAddons was present in version [4.44](https://github.com/pulumi/terraform-provider-aws/commit/c4722a9def99029e9f35a88d79c799cbedc2c384) and was no longer in [4.45](https://github.com/pulumi/terraform-provider-aws/commit/6e942971264a21cf44912f630db330e985840240) this pr will add that back in. 
Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
