### PR TITLE
Marks SSE Configuration as Computed for Legacy S3 Bucket

### DIFF
--- a/internal/service/s3legacy/bucket_legacy.go
+++ b/internal/service/s3legacy/bucket_legacy.go
@@ -572,6 +572,7 @@ func ResourceBucketLegacy() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {


### PR DESCRIPTION
Marks SSE configuration as Computed for legacy S3 bucket.

Resolves https://github.com/pulumi/pulumi-aws/issues/2403